### PR TITLE
Product ID precisa ser o SKU do produto

### DIFF
--- a/functions/lib/integration/new-transaction.js
+++ b/functions/lib/integration/new-transaction.js
@@ -13,7 +13,7 @@ module.exports = (order, appConfig, storeId, appSdk, store) => {
         const image = product.pictures.find(picture => picture.normal && picture.normal.url)
 
         PRODUCTS[index] = {
-          id_product: item.product_id,
+          id_product: product.sku,
           name_product: product.name,
           url_product: product.permalink || `${store.homepage}/${product.slug}`,
           url_product_image: image.normal.url,


### PR DESCRIPTION
Resposta do opinioes verificadas

"Exemplo de um pedido que recebemos pela plataforma de vocês, note que a referência está esse número extenso e na verdade deve enviar o SKU no lugar da referência e assim não haverá mais esse problema."

O número extenso é o ID do produto, conforme imagem abaixo:
![5](https://user-images.githubusercontent.com/35343551/101673201-a290ac00-3a35-11eb-8d71-ca0d3ff820e9.png)
